### PR TITLE
Updated code to copy icon.ico and hotkeys.cfg to output dir

### DIFF
--- a/alt-tabber.csproj
+++ b/alt-tabber.csproj
@@ -7,9 +7,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>1.0.1</Version>
-    <FileVersion>1.0.1</FileVersion>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <Version>1.0.2</Version>
+    <FileVersion>1.0.2</FileVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
 
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.ico" CopyToPublishDirectory="Always" />
-    <None Include="hotkeys.cfg" CopyToPublishDirectory="Always" />
+    <None Include="icon.ico" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
+    <None Include="hotkeys.cfg" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Added 'CopyToOutputDirectory' onto both 'icon.ico' and 'hotkeys.cfg' to force them to be copied into output dir when building for debug.